### PR TITLE
Fix dodo payments webhook signature validation

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -2370,7 +2370,7 @@ async def get_billing_history(user_id: str, limit: int = 50):
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to get billing history: {str(e)}")
-@api_router.post("/webhooks/dodo")
+@app.post("/webhooks/dodo")
 async def handle_dodo_webhook(request: Request):
     """Enhanced webhook handler with proper validation and debugging"""
     try:

--- a/backend/server.py
+++ b/backend/server.py
@@ -2429,8 +2429,8 @@ async def handle_dodo_webhook(request: Request):
             logger.warning("⚠️ BYPASSING WEBHOOK VALIDATION - DEVELOPMENT MODE ONLY!")
             is_valid = True
         else:
-            # Validate webhook signature
-            is_valid = webhook_validator.validate_webhook(body, signature, timestamp)
+            # Validate webhook signature using Standard Webhooks specification
+            is_valid = webhook_validator.validate_webhook(body, signature, timestamp, webhook_id)
         
         if not is_valid:
             logger.error("❌ Webhook signature validation failed", extra={"component": "subscriptions", "action": "webhook.invalid_signature"})


### PR DESCRIPTION
Fix Dodo Payments webhook signature validation to comply with the Standard Webhooks specification.

The previous implementation used an incorrect `timestamp.payload` signing string format. This PR updates it to the correct `webhook_id.webhook_timestamp.payload` format as per the Standard Webhooks specification, and ensures the `webhook_id` is passed to the validation method.

---
<a href="https://cursor.com/background-agent?bcId=bc-24638f49-9f4b-4ad4-816c-4f3b71652026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24638f49-9f4b-4ad4-816c-4f3b71652026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

