### PR TITLE
Analyze subscription management for unlimited plan

### DIFF
--- a/frontend/src/services/subscriptionService.js
+++ b/frontend/src/services/subscriptionService.js
@@ -158,7 +158,8 @@ class SubscriptionService {
       }
 
       const data = await response.json();
-      return data.payments || [];
+      // Handle both direct array and object with data/payments property
+      return data.data || data.payments || data || [];
     } catch (error) {
       console.error('Error fetching billing history:', error);
       return [];

--- a/test_subscription_display.md
+++ b/test_subscription_display.md
@@ -1,0 +1,77 @@
+# Subscription Display Test Guide
+
+## Summary of Changes
+
+Fixed the subscription management system to properly display unlimited subscriptions in the frontend.
+
+## Changes Made
+
+### Backend (`subscription_service.py`)
+- Modified `get_subscription_status()` to check `current_plan` field first
+- Creates synthetic subscription object for users with unlimited plan but no subscription record
+- Returns proper subscription data structure for unlimited plans
+
+### Frontend (`SubscriptionDashboard.js`)
+- Added support for displaying "Unlimited Plan" and "Premium Access" 
+- Shows "Lifetime Access" badge for unlimited plans without billing dates
+- Hides cancel/payment method buttons for lifetime unlimited plans
+- Added debug logging to troubleshoot subscription display issues
+
+### Frontend (`subscriptionService.js`)
+- Updated billing history handler to support multiple response formats
+- Properly handles data.data, data.payments, or direct array responses
+
+## Testing Steps
+
+1. **Check Backend Response:**
+   ```bash
+   curl "https://englishgpt.everythingenglish.xyz/api/subscriptions/status?user_id=YOUR_USER_ID"
+   ```
+   
+   Expected response for unlimited user:
+   ```json
+   {
+     "has_active_subscription": true,
+     "subscription": {
+       "status": "active",
+       "plan_type": "unlimited",
+       "current_plan": "unlimited",
+       "cancel_at_period_end": false
+     }
+   }
+   ```
+
+2. **Frontend Display:**
+   - Navigate to subscription tab
+   - Should see "Unlimited Plan" with "Premium Access" label
+   - Should show "Active" status badge
+   - May show "Lifetime Access" if no billing date
+   - Should NOT show cancel button for lifetime plans
+
+3. **Billing History:**
+   ```bash
+   curl "https://englishgpt.everythingenglish.xyz/api/subscriptions/billing-history?user_id=YOUR_USER_ID&limit=20"
+   ```
+
+## Deployment
+
+To deploy these changes:
+
+1. **Backend:** Restart the Python backend service
+2. **Frontend:** Rebuild and deploy the React app
+
+## Troubleshooting
+
+If subscription still shows as "Free Plan":
+
+1. Check browser console for debug logs
+2. Verify user's `current_plan` field in database is set to "unlimited"
+3. Check network tab for API response from `/api/subscriptions/status`
+4. Clear browser cache and reload
+
+## Key Fields in Database
+
+The system checks these fields in order:
+1. `assessment_users.current_plan` - Should be "unlimited" for premium users
+2. `assessment_users.subscription_status` - Fallback check for "premium" or "active"
+3. `dodo_subscriptions` table - Active subscription records


### PR DESCRIPTION
Implement display and management for unlimited subscriptions in the frontend subscription tab.

Previously, users with an 'unlimited' plan saw 'No Active Subscription' because the frontend did not correctly interpret their `current_plan` status, and the backend did not always provide a full subscription object for these plans. This PR ensures the frontend correctly displays "Unlimited Plan" and hides irrelevant actions like cancellation for lifetime access.

---
<a href="https://cursor.com/background-agent?bcId=bc-19a66d75-f9d1-432c-ba9d-35a93a319cad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19a66d75-f9d1-432c-ba9d-35a93a319cad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

