### PR TITLE
Monitor api billing history errors

### DIFF
--- a/backend/subscription_service.py
+++ b/backend/subscription_service.py
@@ -36,8 +36,15 @@ class BillingHistoryItem(BaseModel):
 class SubscriptionService:
     """Enhanced service for managing subscriptions and payments with robust webhook processing"""
     
-    def __init__(self, supabase: Client):
-        self.supabase = supabase
+    def __init__(self, supabase: Client = None):
+        if supabase is None:
+            from supabase import create_client
+            import os
+            SUPABASE_URL = os.environ.get('SUPABASE_URL', 'https://zwrwtqspeyajttnuzwkl.supabase.co')
+            SUPABASE_KEY = os.environ.get('SUPABASE_SERVICE_ROLE_KEY') or os.environ.get('SUPABASE_KEY')
+            self.supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+        else:
+            self.supabase = supabase
         logger.info("Initialized SubscriptionService")
     
     async def get_or_create_dodo_customer(self, user_id: str, email: str, name: Optional[str] = None) -> str:


### PR DESCRIPTION
Add fallback Supabase client initialization to `SubscriptionService` to resolve 500 errors on the billing history endpoint.

The `SubscriptionService` was sometimes instantiated without a `supabase` client, leading to `AttributeError` when attempting to access `self.supabase` in methods like `get_billing_history`, resulting in 500 Internal Server Errors. This change ensures a Supabase client is always available by initializing one from environment variables if not explicitly provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffc465bb-b1d0-40e1-9c29-57ca8d1d348d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffc465bb-b1d0-40e1-9c29-57ca8d1d348d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

