### PR TITLE
Fix results page button and feedback submission

### DIFF
--- a/backend/add_feedback_table_migration.sql
+++ b/backend/add_feedback_table_migration.sql
@@ -1,0 +1,47 @@
+-- Migration: Add assessment_feedback table if it doesn't exist
+-- Run this in Supabase SQL Editor if the table is missing
+
+-- Check and create the assessment_feedback table
+CREATE TABLE IF NOT EXISTS assessment_feedback (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  evaluation_id text NOT NULL,
+  user_id text NOT NULL,
+  category text NOT NULL CHECK (category IN ('overall', 'strengths', 'improvements')),
+  accurate boolean NOT NULL,
+  comments text,
+  created_at timestamp with time zone DEFAULT now()
+);
+
+-- Add foreign key constraint if assessment_users table exists
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'assessment_users') THEN
+    -- Check if the foreign key constraint already exists
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints 
+      WHERE constraint_name = 'assessment_feedback_user_id_fkey'
+      AND table_name = 'assessment_feedback'
+    ) THEN
+      ALTER TABLE assessment_feedback 
+      ADD CONSTRAINT assessment_feedback_user_id_fkey 
+      FOREIGN KEY (user_id) 
+      REFERENCES assessment_users(uid) 
+      ON DELETE CASCADE;
+    END IF;
+  END IF;
+END $$;
+
+-- Create indexes if they don't exist
+CREATE INDEX IF NOT EXISTS idx_assessment_feedback_evaluation_id ON assessment_feedback(evaluation_id);
+CREATE INDEX IF NOT EXISTS idx_assessment_feedback_user_id ON assessment_feedback(user_id);
+CREATE INDEX IF NOT EXISTS idx_assessment_feedback_created_at ON assessment_feedback(created_at);
+
+-- Grant permissions
+GRANT ALL ON assessment_feedback TO authenticated;
+GRANT SELECT ON assessment_feedback TO anon;
+
+-- Success message
+DO $$
+BEGIN
+  RAISE NOTICE 'assessment_feedback table created/verified successfully';
+END $$;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4422,9 +4422,18 @@ const handleSignOut = async () => {
     }
     
     // For authenticated users, navigate to question types
-    setSelectedQuestionType(null);
-    setEvaluation(null);
-    setCurrentPage('questionTypes');
+    // Check if we're on a public results page (routed component)
+    const isPublicResultsPage = window.location.pathname.startsWith('/results/');
+    
+    if (isPublicResultsPage) {
+      // Navigate using window.location for public results pages
+      window.location.href = '/dashboard';
+    } else {
+      // Use state-based navigation for main app
+      setSelectedQuestionType(null);
+      setEvaluation(null);
+      setCurrentPage('questionTypes');
+    }
   };
 
   // Public Result route wrapper component to fetch by ID and render ResultsPage

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -41,6 +41,22 @@ CREATE TABLE assessment_evaluations (
 ALTER TABLE assessment_evaluations ADD COLUMN short_id text UNIQUE;
 CREATE INDEX IF NOT EXISTS idx_assessment_evaluations_short_id ON assessment_evaluations(short_id);
 
+-- Assessment Feedback table
+CREATE TABLE assessment_feedback (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  evaluation_id text NOT NULL,
+  user_id text NOT NULL REFERENCES assessment_users(uid) ON DELETE CASCADE,
+  category text NOT NULL CHECK (category IN ('overall', 'strengths', 'improvements')),
+  accurate boolean NOT NULL,
+  comments text,
+  created_at timestamp with time zone DEFAULT now()
+);
+
+-- Create indexes for assessment_feedback
+CREATE INDEX idx_assessment_feedback_evaluation_id ON assessment_feedback(evaluation_id);
+CREATE INDEX idx_assessment_feedback_user_id ON assessment_feedback(user_id);
+CREATE INDEX idx_assessment_feedback_created_at ON assessment_feedback(created_at);
+
 -- Assessment Badges table
 CREATE TABLE assessment_badges (
   id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,


### PR DESCRIPTION
Corrects "Start a new question" button navigation for signed-in users and fixes feedback submission 500 error by adding the missing database table.

The "Start a new question" button on public results pages (`/results/:id`) for signed-in users was causing a full page reload instead of navigating to the question types page, as `setCurrentPage` is not effective in routed components. The fix now uses `window.location.href` for this specific scenario. The feedback submission failed with a 500 error because the `assessment_feedback` table was missing in the Supabase database; this PR adds the table definition and a migration script.

---
<a href="https://cursor.com/background-agent?bcId=bc-dddee8fd-6ef6-4882-94d0-da60a30a9721">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dddee8fd-6ef6-4882-94d0-da60a30a9721">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

