### PR TITLE
Fix conditional react hook usage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -340,13 +340,13 @@ const AnalyticsDashboard = ({ onBack, userStats, user, evaluations, onUpgrade })
     const plan = userStats.currentPlan?.toLowerCase();
     return plan === 'unlimited';
   };
-
-  if (!hasUnlimitedAccess()) {
-    return <LockedAnalyticsPage onBack={onBack} upgradeType="unlimited" page="analytics" />;
-  }
   
   // Fetch AI recommendations when component mounts or evaluations change
+  // This hook must be called before any conditional returns (React rules of hooks)
   useEffect(() => {
+    // Only fetch recommendations if user has unlimited access
+    if (!hasUnlimitedAccess()) return;
+    
     const fetchRecommendations = async () => {
       if (!user?.id || evaluations.length === 0) return;
       
@@ -381,6 +381,11 @@ const AnalyticsDashboard = ({ onBack, userStats, user, evaluations, onUpgrade })
     
     fetchRecommendations();
   }, [user, evaluations.length]);
+
+  // Check access after hooks (React rules of hooks requirement)
+  if (!hasUnlimitedAccess()) {
+    return <LockedAnalyticsPage onBack={onBack} upgradeType="unlimited" page="analytics" />;
+  }
 
   // Prepare chart data
   const parsedEvaluations = (evaluations || []).map((e) => {


### PR DESCRIPTION
Refactor `AnalyticsDashboard` to move `useEffect` before conditional return, resolving the 'React Hook is called conditionally' error.

The `useEffect` hook was previously called after a conditional return, violating React's rules of hooks. By moving the hook to the top level and placing the access check inside the effect, we ensure hooks are called unconditionally while maintaining the original logic of only fetching recommendations for users with unlimited access.

---
<a href="https://cursor.com/background-agent?bcId=bc-a877ab8d-6ef7-46e4-908e-f975bdf033f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a877ab8d-6ef7-46e4-908e-f975bdf033f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

