### PR TITLE
Fix grade display mismatch for AI grading

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -840,6 +840,7 @@ QUESTION_TOTALS = {
     "igcse_directed": {"total": 40, "components": {"reading": 15, "writing": 25}},
     # A-Level
     "alevel_directed": {"total": 10, "components": {"ao1": 5, "ao2": 5}},
+    "alevel_directed_writing": {"total": 10, "components": {"ao1": 5, "ao2": 5}},
     "alevel_comparative": {"total": 15, "components": {"ao1": 5, "ao3": 10}},
     "alevel_text_analysis": {"total": 25, "components": {"ao1": 5, "ao3": 20}},
 }
@@ -876,7 +877,9 @@ def compute_overall_grade(question_type: str, reading_marks: Optional[str], writ
         achieved += parse_marks_value(writing_marks)
     if "ao1" in components:
         achieved += parse_marks_value(ao1_marks)
-    # For AO3 we will pass in through ao2_or_ao3_marks parameter
+    # For AO2 and AO3 we will pass in through ao2_or_ao3_marks parameter
+    if "ao2" in components:
+        achieved += parse_marks_value(ao2_or_ao3_marks)
     if "ao3" in components:
         achieved += parse_marks_value(ao2_or_ao3_marks)
 


### PR DESCRIPTION
Fixes incorrect grade calculation for A-level questions by including AO2 marks and adding missing configuration for `alevel_directed_writing`.

The `compute_overall_grade` function was not summing `ao2` component marks for A-level directed questions, leading to an incorrect total grade displayed in the UI. Additionally, the `alevel_directed_writing` question type was missing from the `QUESTION_TOTALS` configuration, preventing its grade from being computed dynamically.

---
<a href="https://cursor.com/background-agent?bcId=bc-308062c3-a638-4e05-aa0c-1010b3a0f15c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-308062c3-a638-4e05-aa0c-1010b3a0f15c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

