### PR TITLE
Fix missing jsx closing tag

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -271,7 +271,7 @@ const PricingPage = ({ onBack, user }) => {
                 Coming After Launch
               </button>
             </div>
-          </div>
+          </motion.div>
 
           {/* Future Yearly Plan */}
           <motion.div 


### PR DESCRIPTION
Fix JSX syntax error by replacing `</div>` with `</motion.div>` to correctly close a `<motion.div>` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ab631ea-0229-4536-b25c-419d3acd43b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ab631ea-0229-4536-b25c-419d3acd43b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

