### PR TITLE
Fix missing motion.div closing tag

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -309,7 +309,7 @@ const PricingPage = ({ onBack, user }) => {
                 Coming After Launch
               </button>
             </div>
-          </div>
+          </motion.div>
         </motion.div>
 
         {/* Launch Modal */}


### PR DESCRIPTION
Fix JSX syntax error by changing a `</div>` to `</motion.div>` to correctly close a `motion.div` element.

---
<a href="https://cursor.com/background-agent?bcId=bc-1512b879-1924-41b5-9db1-b26951ebd782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1512b879-1924-41b5-9db1-b26951ebd782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

